### PR TITLE
Update config file to cope with optional env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ export KALEIDO_NODE_URL=https://username:password@u0nc4noce4-u0c5qcrhgs-rpc.us0-
 > You can also use the Polygon Mumbai test network as the target, with `--network mumbai`. Set the environment variables `MUMBAI_NODE_URL` and `MUMBAI_PRIV_KEY` accordingly. If you use this option, there's no need to deploy the smart contract. You can use the contract that's already been deployed to Mumbai.
 
 ```
-npx hardhat run scripts/deploy.js --network kaleido
+$ npx hardhat run scripts/deploy.js --network kaleido
 deploying verifier
 deploying state
 Verifier contract deployed to 0xf7933EdC82Face032402dBC197280045B327F4ee from 0x6b2807d1074ae6E1ab022E1bdb7C0C8C1Eff1BDF

--- a/issuer/upload-claims/hardhat.config.js
+++ b/issuer/upload-claims/hardhat.config.js
@@ -1,17 +1,24 @@
 require('@nomiclabs/hardhat-ethers');
 require('@openzeppelin/hardhat-upgrades');
 
+const networks = {};
+
+if (process.env.KALEIDO_NODE_URL) {
+  networks.kaleido = {
+    url: process.env.KALEIDO_NODE_URL
+  };
+}
+
+
+if (process.env.MUMBAI_NODE_URL) {
+  networks.mumbai = {
+    url: process.env.MUMBAI_NODE_URL,
+    accounts: [process.env.MUMBAI_PRIV_KEY]
+  };
+}
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  networks: {
-    kaleido: {
-      url: process.env.KALEIDO_NODE_URL,
-    },
-    mumbai: {
-      url: process.env.MUMBAI_NODE_URL,
-      accounts: [process.env.MUMBAI_PRIV_KEY],
-    },
-  },
+  networks,
   solidity: {
     compilers: [
       {


### PR DESCRIPTION
Signed-off-by: Chengxuan Xing <chengxuan.xing@kaleido.io>

Hit the following error when running the readme as is:
```
cxing@Chengxuans-MacBook-Pro upload-claims % npx18 hardhat run scripts/deploy.js --network kaleido
Error HH8: There's one or more errors in your config file:

  * Invalid value undefined for HardhatConfig.networks.mumbai.url - Expected a value of type string.
  * Invalid account: #0 for network: mumbai - Expected string, received undefined
  
To learn more about Hardhat's configuration, please go to https://hardhat.org/config/

For more info go to https://hardhat.org/HH8 or run Hardhat with --show-stack-traces
```