### PR TITLE
Do not add issued user claims to the claims tree

### DIFF
--- a/holder/wallet/index.js
+++ b/holder/wallet/index.js
@@ -63,12 +63,12 @@ async function getHolderInputs() {
 
 async function getClaimInputs() {
   const claimsDir = path.join(os.homedir(), `iden3/${holderName}/received-claims`);
-  const claimFiles = fs.readdirSync(claimsDir).filter(file => file.match(CLAIM_FILE_PATTERN));
+  const claimFiles = fs.readdirSync(claimsDir).filter((file) => file.match(CLAIM_FILE_PATTERN));
   if (claimFiles.length === 0) {
-    throw Error(`There are no received claims in ${claimsDir}`)
+    throw Error(`There are no received claims in ${claimsDir}`);
   }
   if (claimFiles.length > 1) {
-    throw Error(`There are multiple received claims in ${claimsDir}. Currently only a single one is supported.`)
+    throw Error(`There are multiple received claims in ${claimsDir}. Currently only a single one is supported.`);
   }
   const content = fs.readFileSync(path.join(claimsDir, claimFiles[0]));
   const inputs = JSON.parse(content);
@@ -211,7 +211,7 @@ async function generateProof(challenge) {
     timestamp: Math.floor(Date.now() / 1000),
   };
   console.log(inputs);
-  await generateWitness(inputs,WITNESS_FILE );
+  await generateWitness(inputs, WITNESS_FILE);
   const { proof, publicSignals } = await prove(WITNESS_FILE);
   await verify(proof, publicSignals);
   await sendCallback(challenge, proof, publicSignals, holderInputs.userID);
@@ -229,7 +229,7 @@ async function sendCallback(challengeRequest, proof, publicSignals, holderId) {
     thid: challengeRequest.thid,
     typ: challengeRequest.typ,
     type: AUTHORIZATION_RESPONSE_MESSAGE_TYPE,
-    from: Id.fromBigInt(BigInt(holderId)).string(),
+    from: '112HRbKDYBpjqxXA7pCQaXKK9YG6HbmE8hsp6s3nnD',
     to: challengeRequest.from,
     body: {
       message: challengeRequest.body.message,
@@ -245,7 +245,7 @@ async function sendCallback(challengeRequest, proof, publicSignals, holderId) {
       url,
       data: challengeResponse,
     });
-    console.log(`Success response from the verifier server: ${JSON.stringify({status: result.status, message: result.data})}`);
+    console.log(`Success response from the verifier server: ${JSON.stringify({ status: result.status, message: result.data })}`);
   } catch (error) {
     if (error.response) {
       // The request was made and the server responded with a status code
@@ -259,7 +259,7 @@ async function sendCallback(challengeRequest, proof, publicSignals, holderId) {
       // http.ClientRequest in node.js
       console.log(error.request);
     }
-    console.log(`Callback to ${url} failed: ${error.message}. Please check the verifier server logs for more details.`)
+    console.log(`Callback to ${url} failed: ${error.message}. Please check the verifier server logs for more details.`);
     throw error;
   }
 }
@@ -292,7 +292,7 @@ try {
       process.exit(0);
     })
     .catch((err) => {
-      console.error("Error:", err.message);
+      console.error('Error:', err.message);
       process.exit(1);
     });
 } catch (err) {

--- a/identity/internal/challenge.go
+++ b/identity/internal/challenge.go
@@ -144,9 +144,6 @@ func RespondToChallenge() {
 	targetClaim, err := loadClaim(*holderNameStr)
 	assertNoError(err)
 
-	claimMTProof, err := merkletree.NewProofFromBytes(targetClaim.IssuerClaimMtpBytes)
-	assertNoError(err)
-
 	claimNonRevMtp, err := merkletree.NewProofFromBytes(targetClaim.IssuerClaimNonRevMtpBytes)
 	assertNoError((err))
 
@@ -198,7 +195,6 @@ func RespondToChallenge() {
 
 	inputsUserClaim := circuits.Claim{
 		Claim:     targetClaim.IssuerClaim,
-		Proof:     claimMTProof,
 		TreeState: issuerClaimTreeState,
 		NonRevProof: &circuits.ClaimNonRevStatus{
 			TreeState: issuerClaimTreeState,
@@ -234,7 +230,7 @@ func persistInputsForChallenge(name string, inputs circuits.AtomicQuerySigInputs
 	return nil
 }
 
-func loadClaim(name string) (*ClaimInputs, error) {
+func loadClaim(name string) (*ClaimInputsForSigCircuit, error) {
 	homedir, _ := os.UserHomeDir()
 	claimsPath := filepath.Join(homedir, fmt.Sprintf("iden3/%s/received-claims", name))
 	files, err := os.ReadDir(claimsPath)
@@ -254,7 +250,7 @@ func loadClaim(name string) (*ClaimInputs, error) {
 		return nil, err
 	}
 
-	var claim ClaimInputs
+	var claim ClaimInputsForSigCircuit
 	err = json.Unmarshal(content, &claim)
 	if err != nil {
 		return nil, err

--- a/identity/internal/utils.go
+++ b/identity/internal/utils.go
@@ -74,7 +74,26 @@ type stateTransitionInputs struct {
 	SignatureS              string           `json:"signatureS"`
 }
 
-type ClaimInputs struct {
+type ClaimInputsForSigCircuit struct {
+	IssuerAuthState            *issuerState     `json:"issuerAuthState"`
+	IssuerClaim                *core.Claim      `json:"issuerClaim"`
+	IssuerState_ClaimsTreeRoot *merkletree.Hash `json:"issuerState_ClaimsTreeRoot"`
+	IssuerState_RevTreeRoot    *merkletree.Hash `json:"issuerState_RevTreeRoot"`
+	IssuerState_RootsTreeRoot  *merkletree.Hash `json:"issuerState_RootsTreeRoot"`
+	IssuerState_State          *merkletree.Hash `json:"issuerState_State"`
+	IssuerClaimNonRevMtp       []string         `json:"issuerClaimNonRevMtp"`
+	IssuerClaimNonRevMtpBytes  []byte           `json:"issuerClaimNonRevMtpBytes"`
+	IssuerClaimNonRevMtpAuxHi  *merkletree.Hash `json:"issuerClaimNonRevMtpAuxHi"`
+	IssuerClaimNonRevMtpAuxHv  *merkletree.Hash `json:"issuerClaimNonRevMtpAuxHv"`
+	IssuerClaimNonRevMtpNoAux  string           `json:"issuerClaimNonRevMtpNoAux"`
+	ClaimSchema                string           `json:"claimSchema"`
+	IssuerClaimSignatureR8X    string           `json:"issuerClaimSignatureR8x"`
+	IssuerClaimSignatureR8Y    string           `json:"issuerClaimSignatureR8y"`
+	IssuerClaimSignatureS      string           `json:"issuerClaimSignatureS"`
+}
+
+// Not currently used
+type ClaimInputsForMTPCircuit struct {
 	IssuerAuthState            *issuerState     `json:"issuerAuthState"`
 	IssuerClaim                *core.Claim      `json:"issuerClaim"`
 	IssuerClaimMtp             []string         `json:"issuerClaimMtp"`


### PR DESCRIPTION
As we are using the signature based circuit for generating and verifying the zk proofs, we do not need to add the issued claims to the claims tree. This avoids the concern that the hashes of PII (included in the claims) will be uploaded to the State contract and violates regulations in certain jurisdictions (GDPR, CCPA etc.) For the background see https://github.com/kaleido-io/kaleido-iden3-samples/issues/10#issuecomment-1384624126

This also includes a workaround for tolerating the incorrect checksum by the go-iden3-core library. For the background see https://github.com/kaleido-io/kaleido-iden3-samples/issues/14#issuecomment-1382629290