### PR TITLE
Improve /callback error handling and response processing

### DIFF
--- a/verifier/server/app.js
+++ b/verifier/server/app.js
@@ -37,7 +37,6 @@ app.get('/api/sign-in', (req, res) => {
 });
 
 app.post('/api/callback', (req, res) => {
-  console.log('callback');
   callback(req, res);
 });
 
@@ -98,35 +97,43 @@ async function getQR(req, res) {
 
 // Callback verifies the proof after sign-in callbacks
 async function callback(req, res) {
-  // Get session ID from request
-  const sessionId = req.query.sessionId;
-
-  // get JWZ token params from the post request
-  const raw = await getRawBody(req);
-  const authResponse = JSON.parse(raw);
-
-  // fetch authRequest from sessionID
-  const authRequest = requestMap.get(`${sessionId}`);
-
-  console.log(authRequest);
-
-  // Locate the directory that contains circuit's verification keys
-  const verificationKeyloader = new loaders.FSKeyLoader(join(__dirname, './keys'));
-  const sLoader = new loaders.UniversalSchemaLoader('ipfs.io');
-
-  // Add Polygon RPC node endpoint - needed to read on-chain state and identity state contract address
-  const ethStateResolver = new resolver.EthStateResolver(jsonrpcUrl, stateContract);
-
-  // EXECUTE VERIFICATION
-  const verifier = new auth.Verifier(verificationKeyloader, sLoader, ethStateResolver);
-
+  
   try {
+    // Get session ID from request
+    const sessionId = req.query.sessionId;
+
+    // get JWZ token params from the post request
+    const raw = await getRawBody(req);
+    const authResponse = JSON.parse(raw);
+    console.log("callback body:", JSON.stringify(authResponse, null, 2));
+
+    // fetch authRequest from sessionID
+    const authRequest = requestMap.get(`${sessionId}`);
+    console.log("original request:", JSON.stringify(authRequest, null, 2));
+
+    if (!authRequest) {
+      throw Error(`Original request not found for session ID: ${sessionId}`);
+    }
+
+    // Locate the directory that contains circuit's verification keys
+    const verificationKeyloader = new loaders.FSKeyLoader(join(__dirname, './keys'));
+    const sLoader = new loaders.UniversalSchemaLoader('ipfs.io');
+
+    // Add Polygon RPC node endpoint - needed to read on-chain state and identity state contract address
+    const ethStateResolver = new resolver.EthStateResolver(jsonrpcUrl, stateContract);
+
+    // EXECUTE VERIFICATION
+    const verifier = new auth.Verifier(verificationKeyloader, sLoader, ethStateResolver);
+
     await verifier.verifyAuthResponse(authResponse, authRequest);
+
+    return res
+      .status(200)
+      .json({ message: `user with ID: ${authResponse.from} successfully authenticated` });
   } catch (error) {
-    return res.status(500).send(error);
+    console.log("Error: %s", error);
+    return res
+      .status(500)
+      .json({ error: error.message });
   }
-  return res
-    .status(200)
-    .set('Content-Type', 'application/json')
-    .send('user with ID: ' + authResponse.from + ' Succesfully authenticated');
 }


### PR DESCRIPTION
A few tweaks:
- moves the rest of the callback handler within the `try` block
- logs the request body (the auth response)
- adds some error checks (e.g. if session ID unknown)
- logs the error
- formats the error response in JSON
- simplification: use `res.json`

FYI @jimthematrix @Chengxuan 