### PR TITLE
Draft: First cut at document verification claim example

### DIFF
--- a/holder/wallet/snark/witness_calculator.js
+++ b/holder/wallet/snark/witness_calculator.js
@@ -152,8 +152,8 @@ class WitnessCalculator {
           this.instance.exports.setInputSignal(hMSB, hLSB, i);
           input_counter++;
         } catch (err) {
-          // console.log(`After adding signal ${i} of ${k}`)
-          throw new Error(err);
+          console.error(`Error adding signal ${i} of ${k}: ${err}`)
+          throw err;
         }
       }
     });

--- a/identity/Makefile
+++ b/identity/Makefile
@@ -45,4 +45,4 @@ $(IDEN3_DIR)/AliceWonder:
 	go run main.go init --name AliceWonder
 
 clean:
-	rm -fr $(IDEN3_DIR)
+	cd $(IDEN3_DIR) && rm -fr JohnDoe/ AliceWonder/ identities.json 

--- a/identity/internal/claim.go
+++ b/identity/internal/claim.go
@@ -24,8 +24,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-
-	// "time"
+	"time"
 
 	"github.com/iden3/go-circuits"
 	core "github.com/iden3/go-iden3-core"
@@ -116,7 +115,7 @@ func createBasicClaim(holderId core.ID, revNonce uint64) *core.Claim {
 		core.WithIndexDataInts(docStatusHash, nil),
 		// core.WithValueDataInts(big.NewInt(int64(VERIFIED)), nil),
 		core.WithRevocationNonce(revNonce),
-		// core.WithExpirationDate(time.Now().AddDate(0, 3, 0)),
+		core.WithExpirationDate(time.Now().AddDate(0, 3, 0)),
 	)
 	assertNoError(err)
 

--- a/verifier/server/package-lock.json
+++ b/verifier/server/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@iden3/js-crypto": "^0.0.3",
         "@iden3/js-iden3-auth": "^0.1.4",
         "tslib": "^2.4.0",
         "yargs": "^17.6.2"
@@ -711,6 +712,15 @@
       "dependencies": {
         "fastfile": "0.0.20",
         "ffjavascript": "^0.2.48"
+      }
+    },
+    "node_modules/@iden3/js-crypto": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@iden3/js-crypto/-/js-crypto-0.0.3.tgz",
+      "integrity": "sha512-fHO8edwKmAr8dnWlbIZhmQ5KEgViXGvmLyA/G++4LjOOoGa46sVBG0hWDYaBdlRCd68yXsemrKyyJUXrXP+/jw==",
+      "dependencies": {
+        "blake-hash": "^2.0.0",
+        "ffjavascript": "^0.2.57"
       }
     },
     "node_modules/@iden3/js-iden3-auth": {
@@ -5847,6 +5857,15 @@
       "requires": {
         "fastfile": "0.0.20",
         "ffjavascript": "^0.2.48"
+      }
+    },
+    "@iden3/js-crypto": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@iden3/js-crypto/-/js-crypto-0.0.3.tgz",
+      "integrity": "sha512-fHO8edwKmAr8dnWlbIZhmQ5KEgViXGvmLyA/G++4LjOOoGa46sVBG0hWDYaBdlRCd68yXsemrKyyJUXrXP+/jw==",
+      "requires": {
+        "blake-hash": "^2.0.0",
+        "ffjavascript": "^0.2.57"
       }
     },
     "@iden3/js-iden3-auth": {

--- a/verifier/server/package.json
+++ b/verifier/server/package.json
@@ -3,6 +3,7 @@
     "start": "node app.js"
   },
   "dependencies": {
+    "@iden3/js-crypto": "^0.0.3",
     "@iden3/js-iden3-auth": "^0.1.4",
     "tslib": "^2.4.0",
     "yargs": "^17.6.2"


### PR DESCRIPTION
This adapts the current claim issuance and verification to a document verification use case. For expedience, it reuses the KYC schema's `CountryOfResidenceCredential` type rather than defining its own schema (which would need to be published in order for the verifier to fetch it). But conceptually it's a `DocumentStatus` type with a `docStatusHash` field in claim slot IndexA.
