### PR TITLE
Add command line args for claim schema, index and value data, expiry date

### DIFF
--- a/identity/Makefile
+++ b/identity/Makefile
@@ -29,7 +29,7 @@ AliceWonder: $(IDEN3_DIR)/AliceWonder
 identities: JohnDoe AliceWonder
 
 issue-claim: identities
-	go run main.go claim --issuer JohnDoe --holder $(AW_ID) --schemaType AgeCredential --index 19950704 --nonce $(CLAIM_NONCE)
+	go run main.go claim --issuer JohnDoe --holder $(AW_ID) --schemaType AgeCredential --indexDataA 19950704 --nonce $(CLAIM_NONCE)
 
 receive-claim: identities
 	mkdir -p $(RECEIVED_CLAIMS_DIR)

--- a/identity/Makefile
+++ b/identity/Makefile
@@ -29,7 +29,7 @@ AliceWonder: $(IDEN3_DIR)/AliceWonder
 identities: JohnDoe AliceWonder
 
 issue-claim: identities
-	go run main.go claim --issuer JohnDoe --holder $(AW_ID) --nonce $(CLAIM_NONCE)
+	go run main.go claim --issuer JohnDoe --holder $(AW_ID) --schemaType AgeCredential --index 19950704 --nonce $(CLAIM_NONCE)
 
 receive-claim: identities
 	mkdir -p $(RECEIVED_CLAIMS_DIR)

--- a/identity/internal/utils.go
+++ b/identity/internal/utils.go
@@ -359,7 +359,7 @@ func loadUserId(issuerNameStr string) (*core.ID, error) {
 	issuerIdBigInt := &big.Int{}
 	issuerIdBigInt.SetString(issuerIdStr, 10)
 	issuerId, err := core.IDFromInt(issuerIdBigInt)
-	fmt.Println("-> Issuer identity: ", issuerId.String())
+	fmt.Println("-> Issuer identity:", issuerId.String())
 	if err != nil {
 		fmt.Printf("-> Failed to load issuer ID from string: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
For #30 -- issuing various claims. This adds a few command line args, to make it easier to issue various claims against different schema. The KYC schema is still the default.

I've not updated the README yet. Please LMK if this approach looks OK, and I'll be happy to make those updates.

FYI @jimthematrix @Chengxuan 
