### PR TITLE
Use js-iden3-auth instead of js-iden3-core

### DIFF
--- a/holder/wallet/package-lock.json
+++ b/holder/wallet/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@iden3/js-iden3-auth": "^0.1.3-intermediate",
-        "@iden3/js-iden3-core": "^0.0.2",
+        "@iden3/js-iden3-auth": "^0.1.4",
         "axios": "^1.2.2",
         "jimp": "^0.16.2",
         "jsqr": "^1.4.0",
@@ -734,19 +733,10 @@
         "ffjavascript": "^0.2.48"
       }
     },
-    "node_modules/@iden3/js-crypto": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@iden3/js-crypto/-/js-crypto-0.0.2.tgz",
-      "integrity": "sha512-vIpFNA6uWDAPCBvbd1F9MlKmWbWY5ipF3KhzjNWZEg3HkswOYQkvJBCEDRJtAhV4d8oMD/5HRTHn/AJXyKZrCA==",
-      "dependencies": {
-        "blake-hash": "^2.0.0",
-        "ffjavascript": "^0.2.57"
-      }
-    },
     "node_modules/@iden3/js-iden3-auth": {
-      "version": "0.1.3-intermediate",
-      "resolved": "https://registry.npmjs.org/@iden3/js-iden3-auth/-/js-iden3-auth-0.1.3-intermediate.tgz",
-      "integrity": "sha512-/IidJP0H1vgqky802IZt0grBcROPv57P0bL7Ddp3ZrEQ/j8EO8XMYMesVieiKCr2QsCSXdzvwv0gkXEMgeIdtg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@iden3/js-iden3-auth/-/js-iden3-auth-0.1.4.tgz",
+      "integrity": "sha512-RU6m9089wP1+8J6CCz4aIcX7jz3xqHp7bOwvA41K/vWN4xo9FfM6bu4ipAo9tKbLT2U/XSyRd6HBYMN7vnuMEQ==",
       "dependencies": {
         "@iden3/js-jwz": "^0.1.3",
         "axios": "^0.27.2",
@@ -846,16 +836,6 @@
       "dependencies": {
         "big-integer": "^1.6.42",
         "blakejs": "^1.1.0"
-      }
-    },
-    "node_modules/@iden3/js-iden3-core": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@iden3/js-iden3-core/-/js-iden3-core-0.0.2.tgz",
-      "integrity": "sha512-gU9unxMvseBOtCRN6G4nwU+EDlUXGjHPzUqeO4UcusXrtfmhmWXnsG7dSe2HbgR4e6PCjG4OPNHq0F0/TJhs9w==",
-      "dependencies": {
-        "@iden3/js-crypto": "0.0.2",
-        "base58-js": "^1.0.4",
-        "cross-sha256": "^1.2.0"
       }
     },
     "node_modules/@iden3/js-jwz": {
@@ -6599,19 +6579,10 @@
         "ffjavascript": "^0.2.48"
       }
     },
-    "@iden3/js-crypto": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@iden3/js-crypto/-/js-crypto-0.0.2.tgz",
-      "integrity": "sha512-vIpFNA6uWDAPCBvbd1F9MlKmWbWY5ipF3KhzjNWZEg3HkswOYQkvJBCEDRJtAhV4d8oMD/5HRTHn/AJXyKZrCA==",
-      "requires": {
-        "blake-hash": "^2.0.0",
-        "ffjavascript": "^0.2.57"
-      }
-    },
     "@iden3/js-iden3-auth": {
-      "version": "0.1.3-intermediate",
-      "resolved": "https://registry.npmjs.org/@iden3/js-iden3-auth/-/js-iden3-auth-0.1.3-intermediate.tgz",
-      "integrity": "sha512-/IidJP0H1vgqky802IZt0grBcROPv57P0bL7Ddp3ZrEQ/j8EO8XMYMesVieiKCr2QsCSXdzvwv0gkXEMgeIdtg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@iden3/js-iden3-auth/-/js-iden3-auth-0.1.4.tgz",
+      "integrity": "sha512-RU6m9089wP1+8J6CCz4aIcX7jz3xqHp7bOwvA41K/vWN4xo9FfM6bu4ipAo9tKbLT2U/XSyRd6HBYMN7vnuMEQ==",
       "requires": {
         "@iden3/js-jwz": "^0.1.3",
         "axios": "^0.27.2",
@@ -6704,16 +6675,6 @@
             "blakejs": "^1.1.0"
           }
         }
-      }
-    },
-    "@iden3/js-iden3-core": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@iden3/js-iden3-core/-/js-iden3-core-0.0.2.tgz",
-      "integrity": "sha512-gU9unxMvseBOtCRN6G4nwU+EDlUXGjHPzUqeO4UcusXrtfmhmWXnsG7dSe2HbgR4e6PCjG4OPNHq0F0/TJhs9w==",
-      "requires": {
-        "@iden3/js-crypto": "0.0.2",
-        "base58-js": "^1.0.4",
-        "cross-sha256": "^1.2.0"
       }
     },
     "@iden3/js-jwz": {

--- a/holder/wallet/package.json
+++ b/holder/wallet/package.json
@@ -9,8 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@iden3/js-iden3-auth": "^0.1.3-intermediate",
-    "@iden3/js-iden3-core": "^0.0.2",
+    "@iden3/js-iden3-auth": "^0.1.4",
     "axios": "^1.2.2",
     "jimp": "^0.16.2",
     "jsqr": "^1.4.0",


### PR DESCRIPTION
Drops the use of `js-iden3-core` for now, given update in https://github.com/iden3/js-iden3-auth/issues/37#issuecomment-1400693946

Also bumps to js-iden3-auth v0.1.4. See https://github.com/iden3/js-iden3-auth/issues/37#issuecomment-1402607270

FYI @jimthematrix @Chengxuan 