### PR TITLE
Add docver schema with DocumentStatus schema type

### DIFF
--- a/holder/wallet/index.js
+++ b/holder/wallet/index.js
@@ -182,6 +182,7 @@ const VALUE_SLOT_B = 7;
 const SLOT_NAME_TO_INDEX = {
   birthDay: INDEX_SLOT_A,
   countryCode: INDEX_SLOT_A,
+  docStatusHash: INDEX_SLOT_A,
 };
 
 async function generateProof(challenge) {

--- a/holder/wallet/index.js
+++ b/holder/wallet/index.js
@@ -173,6 +173,17 @@ async function scanQR() {
   return JSON.parse(result.data);
 }
 
+const INDEX_SLOT_A = 2;
+const INDEX_SLOT_B = 3;
+const VALUE_SLOT_A = 6;
+const VALUE_SLOT_B = 7;
+
+// This assumes the KYC schema for now. TODO: incorporate schema URL or actually look up slot in schema
+const SLOT_NAME_TO_INDEX = {
+  birthDay: INDEX_SLOT_A,
+  countryCode: INDEX_SLOT_A,
+};
+
 async function generateProof(challenge) {
   const WITNESS_FILE = path.join(
     workDir,
@@ -185,10 +196,12 @@ async function generateProof(challenge) {
   const challengeInputs = await getChallengeInputs();
 
   const queryRequest = challenge.body.scope[0].rules.query.req;
+  console.log("queryRequest:", JSON.stringify(queryRequest, null, 2));
+
   const queryProperty = Object.keys(queryRequest)[0];
-  if (queryProperty != "birthDay") {
-    const msg = `As of now only the 'birthDay' property is supported in the challenge query. Had ${queryProperty}`;
-    throw new Error(msg);
+  const slotIndex = SLOT_NAME_TO_INDEX[queryProperty];
+  if (!slotIndex) {
+    throw new Error(`As of now the '${queryProperty}' property is not supported in the challenge query.`);
   }
   const queryExp = queryRequest[queryProperty];
   const exp = Object.entries(queryExp)[0];
@@ -197,8 +210,8 @@ async function generateProof(challenge) {
     ...holderInputs,
     ...claimInputs,
     ...challengeInputs,
-    slotIndex: 2, // index of slot A is where we store the claim's birthday (eg. "20000704")
-    operator: translateOperator(exp[0]), // the "EQUAL" operator
+    slotIndex, 
+    operator: translateOperator(exp[0]),
     value: [
       exp[1],
       "0",
@@ -267,7 +280,7 @@ async function generateProof(challenge) {
     ],
     timestamp: Math.floor(Date.now() / 1000),
   };
-  console.log(inputs);
+  console.log("inputs:", inputs);
   await generateWitness(inputs, WITNESS_FILE);
   const { proof, publicSignals } = await prove(WITNESS_FILE);
   await verify(proof, publicSignals);

--- a/holder/wallet/snark/witness_calculator.js
+++ b/holder/wallet/snark/witness_calculator.js
@@ -152,8 +152,8 @@ class WitnessCalculator {
           this.instance.exports.setInputSignal(hMSB, hLSB, i);
           input_counter++;
         } catch (err) {
-          // console.log(`After adding signal ${i} of ${k}`)
-          throw new Error(err);
+          console.error(`Error adding signal ${i} of ${k}: ${err}`)
+          throw err;
         }
       }
     });

--- a/identity/Makefile
+++ b/identity/Makefile
@@ -26,6 +26,10 @@ issue-claim: identities
 issue-claim-fails-challenge: identities
 	go run main.go claim --issuer JohnDoe --holder AliceWonder --schemaType AgeCredential --indexDataA 20220704
 
+.PHONY: issue-docver-claim
+issue-docver-claim: identities
+	go run main.go claim --issuer JohnDoe --holder AliceWonder --schemaFile schemas/docver.json-ld --schemaType DocumentStatus --indexDataA '"PASSPORT/CA/ZZ123456789:VERIFIED"' --expiryDays 90
+
 .PHONY: respond-to-challenge
 respond-to-challenge:
 	go run main.go respond-to-challenge --holder AliceWonder --qrcode ~/Downloads/challenge-qr.png
@@ -43,3 +47,7 @@ clean:
 .PHONY: clean-ids
 clean-ids:
 	cd $(IDEN3_WORKDIR) && rm -fr JohnDoe AliceWonder identities.json
+
+.PHONY: clean-claims
+clean-claims:
+	cd $(IDEN3_WORKDIR) && rm -fr JohnDoe/private/claims/genericClaim-*.json AliceWonder/private/received-claims/genericClaim-*.json AliceWonder/challenge.json

--- a/identity/schemas/docver.json-ld
+++ b/identity/schemas/docver.json-ld
@@ -1,0 +1,25 @@
+{
+  "@context": [
+    {
+      "@version": 1.1,
+      "@protected": true,
+      "id": "@id",
+      "type": "@type",
+      "DocumentStatus": {
+        "@id": "https://github.com/kaleido-io/kaleido-iden3-samples/blob/docver-schema/identity/schemas/docver.json-ld#DocumentStatus",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "docver": "https://github.com/kaleido-io/kaleido-iden3-samples/blob/docver-schema/identity/schemas/docver.md#",
+          "serialization": "https://github.com/iden3/claim-schema-vocab/blob/main/credentials/serialization.md#",
+          "docStatusHash": {
+            "@id": "docver:docStatusHash",
+            "@type": "serialization:IndexDataSlotA"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/verifier/server/app.js
+++ b/verifier/server/app.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const { join } = require('path');
-const { Poseidon } = require('@iden3/js-crypto');
 const { auth, resolver, loaders } = require('@iden3/js-iden3-auth');
 const getRawBody = require('raw-body');
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 const argv = yargs(hideBin(process.argv)).option('state-contract', { string: true }).argv;
+
+const examples = require('./examples');
 
 let publicHost = argv['public-host'];
 if (!publicHost) {
@@ -33,75 +34,47 @@ const port = 8080;
 app.use(express.static('static'));
 
 app.get('/api/sign-in', (req, res) => {
-  console.log('get QR');
+  console.log('get sign-in / challenge QR data');
   getQR(req, res);
 });
 
 app.post('/api/callback', (req, res) => {
+  console.log('handle callback');
   callback(req, res);
 });
 
 app.listen(port, () => {
-  console.log('server running on port 8080');
+  console.log('server running on port', port);
 });
 
 // Create a map to store the auth requests and their session IDs
 const requestMap = new Map();
 
-const utf8 = (str) => new TextEncoder().encode(str);
-
 // GetQR returns auth request
 async function getQR(req, res) {
   // Audience is verifier id
-  console.log("req.query:", req.query);
   const sessionId = parseInt(req.query.sessionId || '1');
   const callbackURL = '/api/callback';
   const audience = '1125GJqgw6YEsKFwj63GY87MMxPL9kwDKxPUiwMLNZ';
   const circuitId = 'credentialAtomicQuerySig';
   const uri = `${publicHost}${callbackURL}?sessionId=${sessionId}`;
 
+  const { example } = req.query;
+  console.log("example:", example)
+
+  const query = examples[example];
+  console.log("query:", query)
+
+  if (!query) {
+    return res.status(404).json({ error: "Example not found" });
+  }
+
   // Generate request for basic authentication
-  const challenge = req.query.challenge || '12345'; // supposed to be unique for every interaction
+  const challenge = '12345'; // supposed to be unique for every interaction
   const request = auth.createAuthorizationRequestWithMessage('test flow', challenge, audience, uri);
 
   request.id = '7f38a193-0918-4a48-9fac-36adfdb8b542';
   request.thid = '7f38a193-0918-4a48-9fac-36adfdb8b542';
-
-  let query;
-  const { example } = req.query;
-  if (!example || example === 'kyc') {
-    query = {
-      allowedIssuers: ['*'],
-      schema: {
-        url: 'https://schema.polygonid.com/jsonld/kyc.json-ld',
-        type: 'AgeCredential',
-      },
-      req: {
-        birthDay: {
-          $lt: 20000101, // birthDay field prior to 2000/01/01,
-        },
-      },
-    };
-  } else if (example === 'docver') {
-    // The credentialAtomicQuerySig circuit is currently limited to checking a single slot,
-    // so we combine the doc ID and status in a single index slot.
-    // TODO: separate doc ID and status into separate claim slots (index and value, respectively).
-    const docStatus = "PASSPORT/CA/ZZ123456789:VERIFIED";
-    const docStatusHash = Poseidon.hashBytes(utf8(docStatus)).toString();
-    query = {
-      allowedIssuers: ['*'],
-      schema: {
-        // TODO: change URL to kaleido main branch, or perhaps use S3
-        url: 'https://raw.githubusercontent.com/nedgar/kaleido-iden3-samples/docver-schema/identity/schemas/docver.json-ld',
-        type: 'DocumentStatus',
-      },
-      req: {
-        docStatusHash: {
-          $eq: docStatusHash,
-        },
-      },    
-    };
-  }
 
   // Add request for a specific proof
   const proofRequest = {
@@ -118,10 +91,10 @@ async function getQR(req, res) {
   // Store auth request in map associated with session ID
   requestMap.set(`${sessionId}`, request);
 
-  return res.status(200).set('Content-Type', 'application/json').send(request);
+  return res.status(200).json(request);
 }
 
-// Callback verifies the proof after sign-in callbacks
+// Callback verifies the proof with response to challenge
 async function callback(req, res) {
   try {
     // Get session ID from request

--- a/verifier/server/examples/docver.js
+++ b/verifier/server/examples/docver.js
@@ -1,0 +1,27 @@
+const { Poseidon } = require("@iden3/js-crypto");
+
+// TODO: change to use the kaleido repo main branch before merging
+const SCHEMA_URL =
+  "https://raw.githubusercontent.com/nedgar/kaleido-iden3-samples/docver-schema/identity/schemas/docver.json-ld";
+
+const utf8 = (str) => new TextEncoder().encode(str);
+
+const docStatusHash = (...args) => Poseidon.hashBytes(utf8(args.join(":")));
+
+const passportCheck = {
+  // The credentialAtomicQuerySig circuit is currently limited to checking a single slot,
+  // so we combine the doc ID and status in a single index slot.
+  // TODO: separate doc ID and status into separate claim slots (index and value, respectively).
+  allowedIssuers: ["*"],
+  schema: {
+    url: SCHEMA_URL,
+    type: "DocumentStatus",
+  },
+  req: {
+    docStatusHash: {
+      $eq: docStatusHash("PASSPORT/CA/ZZ123456789", "VERIFIED").toString(),
+    },
+  },
+};
+
+module.exports = { passportCheck };

--- a/verifier/server/examples/index.js
+++ b/verifier/server/examples/index.js
@@ -1,0 +1,7 @@
+const { ageCheck } = require("./kyc");
+const { passportCheck } = require("./docver");
+
+module.exports = {
+    kyc_age: ageCheck,
+    docver_passport: passportCheck,
+};

--- a/verifier/server/examples/kyc.js
+++ b/verifier/server/examples/kyc.js
@@ -1,0 +1,16 @@
+const SCHEMA_URL = "https://schema.polygonid.com/jsonld/kyc.json-ld";
+
+const ageCheck = {
+  allowedIssuers: ["*"],
+  schema: {
+    url: SCHEMA_URL,
+    type: "AgeCredential",
+  },
+  req: {
+    birthDay: {
+      $lt: 20000101, // birthDay prior to 2000/01/01
+    },
+  },
+};
+
+module.exports = { ageCheck };

--- a/verifier/server/package-lock.json
+++ b/verifier/server/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@iden3/js-crypto": "^0.0.3",
         "@iden3/js-iden3-auth": "^0.1.4",
         "tslib": "^2.4.0",
         "yargs": "^17.6.2"
@@ -711,6 +712,15 @@
       "dependencies": {
         "fastfile": "0.0.20",
         "ffjavascript": "^0.2.48"
+      }
+    },
+    "node_modules/@iden3/js-crypto": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@iden3/js-crypto/-/js-crypto-0.0.3.tgz",
+      "integrity": "sha512-fHO8edwKmAr8dnWlbIZhmQ5KEgViXGvmLyA/G++4LjOOoGa46sVBG0hWDYaBdlRCd68yXsemrKyyJUXrXP+/jw==",
+      "dependencies": {
+        "blake-hash": "^2.0.0",
+        "ffjavascript": "^0.2.57"
       }
     },
     "node_modules/@iden3/js-iden3-auth": {
@@ -5847,6 +5857,15 @@
       "requires": {
         "fastfile": "0.0.20",
         "ffjavascript": "^0.2.48"
+      }
+    },
+    "@iden3/js-crypto": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@iden3/js-crypto/-/js-crypto-0.0.3.tgz",
+      "integrity": "sha512-fHO8edwKmAr8dnWlbIZhmQ5KEgViXGvmLyA/G++4LjOOoGa46sVBG0hWDYaBdlRCd68yXsemrKyyJUXrXP+/jw==",
+      "requires": {
+        "blake-hash": "^2.0.0",
+        "ffjavascript": "^0.2.57"
       }
     },
     "@iden3/js-iden3-auth": {

--- a/verifier/server/package.json
+++ b/verifier/server/package.json
@@ -3,6 +3,7 @@
     "start": "node app.js"
   },
   "dependencies": {
+    "@iden3/js-crypto": "^0.0.3",
     "@iden3/js-iden3-auth": "^0.1.4",
     "tslib": "^2.4.0",
     "yargs": "^17.6.2"

--- a/verifier/server/static/index.js
+++ b/verifier/server/static/index.js
@@ -1,46 +1,8 @@
-const base_url = window.location.origin + window.location.pathname;
-
 window.onload = () => {
-  const qrBtnEl = document.querySelector('.btn-qr');
-  const qrCodeEl = document.querySelector('#qrcode');
-
-  qrBtnEl.addEventListener('click', (e) => {
-    makeDisabled(qrBtnEl, false);
-
-    fetch(base_url + 'api/sign-in')
-      .then((r) => Promise.all([Promise.resolve(r.headers.get('x-id')), r.json()]))
-      .then(([id, data]) => {
-        console.log(data);
-        makeQr(qrCodeEl, data);
-        handleDisplay(qrCodeEl, true);
-        handleDisplay(qrBtnEl, false);
-        return id;
-      })
-      .catch((err) => console.log(err));
+  document.querySelectorAll('.btn-qr').forEach((el) => {
+    el.addEventListener('click', (e) => {
+      const example = e.target.getAttribute("data-example");    
+      location.href = `qr.html?example=${encodeURIComponent(example)}`;
+    });
   });
 };
-
-function makeQr(el, data) {
-  return new QRCode(el, {
-    text: JSON.stringify(data),
-    width: 600,
-    height: 600,
-    colorDark: '#000',
-    colorLight: '#ffffff',
-    correctLevel: QRCode.CorrectLevel.H,
-  });
-}
-
-function handleDisplay(el, needShow, display = 'block') {
-  el.style.display = needShow ? display : 'none';
-}
-
-function makeDisabled(el, disabled, cls = 'disabled') {
-  if (disabled) {
-    el.disabled = true;
-    el.classList.add(cls);
-  } else {
-    el.classList.remove(cls);
-    el.disabled = false;
-  }
-}

--- a/verifier/server/static/qr.html
+++ b/verifier/server/static/qr.html
@@ -9,17 +9,14 @@
         content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet"
         href="styles.css">
-    <script src="index.js"></script>
-    <title>Verifier Demo</title>
+    <script src="lib/qrcode.min.js"></script>
+    <script src="qr.js"></script>
+    <title>Verifier: Challenge QR</title>
 </head>
 
 <body>
     <main class="main-content">
-        <div id="choices">
-            <p>Choose your challenge:</p>
-            <button class="btn-qr" data-example="kyc_age">KYC: Check age</button>
-            <button class="btn-qr" data-example="docver_passport">DocVer: Check passport</button>
-        </div>
+        <div id="qrcode"></div>
     </main>
 </body>
 

--- a/verifier/server/static/qr.js
+++ b/verifier/server/static/qr.js
@@ -1,0 +1,37 @@
+window.onload = () => {
+  const url = new URL(document.URL);
+  const example = url.searchParams.get("example") || 'kyc_age';
+  const qrUrl = `${url.origin}/api/sign-in?example=${encodeURIComponent(example)}`;
+  console.log("qrUrl:", qrUrl);
+  
+  const qrCodeEl = document.querySelector('#qrcode');
+  fetch(qrUrl)
+    .then((r) => {
+      return Promise.all([
+        r.status, 
+        r.headers.get('x-id'),
+        r.json()
+      ])
+    })
+    .then(([status, id, data]) => {
+      console.log({status, id, data});
+      if (status === 200) {
+        makeQr(qrCodeEl, data);
+      } else {
+        console.error(`QR request failed with status: ${status}, error: ${data?.error}`);
+      }
+      return id;
+    })
+    .catch((err) => console.log(err));
+};
+
+function makeQr(el, data) {
+  return new QRCode(el, {
+    text: JSON.stringify(data),
+    width: 600,
+    height: 600,
+    colorDark: '#000',
+    colorLight: '#ffffff',
+    correctLevel: QRCode.CorrectLevel.H,
+  });
+}

--- a/verifier/server/static/styles.css
+++ b/verifier/server/static/styles.css
@@ -13,6 +13,7 @@
 }
 
 body {
+  font-family: sans-serif;
   margin: 0;
   padding: 0;
   background-color: var(--bg);
@@ -33,16 +34,29 @@ body {
   border-radius: 30px;
   height: 650px;
   width: 650px;
-  display: none;
 }
 
-/* CSS */
+#choices p {
+  color: var(--dark-text);
+  font-size: 18px;
+  font-weight: 600;
+}
+
+#choices button {
+  margin-top: 15px;
+}
+
+#choices button:first-of-type {
+  margin-top: 0px;
+}
+
 .btn-qr {
   background-color: transparent;
   border: 2px solid var(--dark);
   border-radius: 15px;
   color: var(--dark-text);
   cursor: pointer;
+  display: block;
   font-size: 16px;
   font-weight: 600;
   min-height: 60px;
@@ -53,7 +67,7 @@ body {
   transition: all 300ms cubic-bezier(0.23, 1, 0.32, 1);
   user-select: none;
   touch-action: manipulation;
-  width: 200px;
+  width: 250px;
   will-change: transform;
 }
 


### PR DESCRIPTION
WIP on extending the verifier server to support different examples of various claim schemas / types.

Just FYI @Chengxuan @jimthematrix. Please LMK if you're working on something similar or have any suggestions.

Next step: pass through `example=` and other query args from landing page to sign-in endpoint.
 