### PR TITLE
Pass network arg through to the various managers

### DIFF
--- a/v2/holder/wallet/index.js
+++ b/v2/holder/wallet/index.js
@@ -4,7 +4,7 @@ const sqlite3 = require('sqlite3');
 const { open } = require('sqlite');
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
-const argv = yargs(hideBin(process.argv)).argv;
+
 const { IdentityManager } = require('./lib/identity');
 const { CredentialManager } = require('./lib/credential');
 const { initializeStateContract } = require('./lib/init-contract');
@@ -25,43 +25,47 @@ async function initDB() {
   return db;
 }
 
-async function exec() {
-  console.log('Initialing SQLite DB');
+async function exec(argv) {
+  const network = argv.network ?? 'kaleido';
+  console.log('Using network:', network);
+
+  console.log('Initializing SQLite DB');
   const db = await initDB();
 
   if (argv.command == 'init-contract') {
     console.log('Initializing state contract');
-    await initializeStateContract(db);
+    await initializeStateContract(network);
   } else if (argv.command == 'list-ids') {
     console.log('Listing existing identities');
-    const idmgr = new IdentityManager(db);
+    const idmgr = new IdentityManager(db, network);
     await idmgr.init();
     const result = await idmgr.getAllIdentities();
     console.log(JSON.stringify(result, null, 2));
   } else if (argv.command == 'create-id') {
     console.log('Creating identity');
-    const idmgr = new IdentityManager(db);
+    const idmgr = new IdentityManager(db, network);
     await idmgr.init();
     await idmgr.createIdentity();
   } else if (argv.command == 'get-gist-proof') {
     console.log('Loading my identity');
-    const idmgr = new IdentityManager(db, argv.network);
+    const idmgr = new IdentityManager(db, network);
     await idmgr.init();
     const result = await idmgr.queryGISTProof();
     console.log(`GIST proof for my identity: ${JSON.stringify(result, null, 2)}`);
   } else if (argv.command == 'fetch-credential') {
     console.log('Downloading offered verifiable credentials');
-    const cvmgr = new CredentialManager(db);
+    const cvmgr = new CredentialManager(db, network);
     await cvmgr.init();
     await cvmgr.downloadCredential(argv.qrcode);
   } else if (argv.command == 'respond-to-challenge') {
     console.log('Respond to challenge');
-    const proofmgr = new ProofManager(db);
+    const proofmgr = new ProofManager(db, network);
     await proofmgr.init();
     await proofmgr.respondToChallenge(argv.qrcode, argv['id-index']);
   }
 }
 
-exec().then(() => {
+const args = yargs(hideBin(process.argv));
+exec(args.argv).then(() => {
   console.log('Done!');
 });

--- a/v2/holder/wallet/lib/credential.js
+++ b/v2/holder/wallet/lib/credential.js
@@ -5,9 +5,9 @@ const { IdentityManager } = require('./identity');
 const { scanQR, initPackageManager } = require('./util');
 
 class CredentialManager {
-  constructor(db) {
+  constructor(db, network) {
     this.db = db;
-    this.idmgr = new IdentityManager(db);
+    this.idmgr = new IdentityManager(db, network);
   }
 
   async init() {

--- a/v2/holder/wallet/lib/identity.js
+++ b/v2/holder/wallet/lib/identity.js
@@ -9,9 +9,11 @@ const { FSPrivateKeyStore } = require('./extensions/keystore');
 const config = require('./config');
 
 class IdentityManager {
-  constructor(db, network = 'kaleido') {
+  constructor(db, network) {
     this.db = db;
+    this.network = network;
     this.config = config[network];
+    // TODO: can get provider and state contract from this.dataStorage.states
     this.provider = new JsonRpcProvider(this.config.url);
     this.stateContract = new Contract(this.config.contractAddress, abi, this.provider);
   }
@@ -22,7 +24,7 @@ class IdentityManager {
     const kms = new KMS();
     kms.registerKeyProvider(KmsKeyType.BabyJubJub, bjjProvider);
 
-    this.dataStorage = await initDataStorage(this.db);
+    this.dataStorage = await initDataStorage(this.db, this.network);
     this.credentialWallet = new CredentialWallet(this.dataStorage);
     this.wallet = new IdentityWallet(kms, this.dataStorage, this.credentialWallet);
 

--- a/v2/holder/wallet/lib/init-contract.js
+++ b/v2/holder/wallet/lib/init-contract.js
@@ -1,4 +1,3 @@
-const http = require('http');
 const {
   CredentialWallet,
   IdentityWallet,
@@ -17,16 +16,14 @@ const {
 const { JsonRpcProvider } = require('@ethersproject/providers');
 const { Wallet } = require('@ethersproject/wallet');
 const nock = require('nock');
-const { IdentityManager } = require('./identity');
 const { initCircuitStorage } = require('./util');
 const config = require('./config');
 
 // This is a workaround.
 // The State contract has a bug where it doesn't work properly if the GIST data is empty,
 // prime a new contract with some states for a dummy credential to allow it to work properly
-async function initializeStateContract() {
-  let conf = Object.assign({}, defaultEthConnectionConfig);
-  Object.assign(conf, config['kaleido']);
+async function initializeStateContract(network) {
+  const conf = Object.assign({}, defaultEthConnectionConfig, config[network]);
 
   const memoryKeyStore = new InMemoryPrivateKeyStore();
   const bjjProvider = new BjjProvider(KmsKeyType.BabyJubJub, memoryKeyStore);

--- a/v2/holder/wallet/lib/proof.js
+++ b/v2/holder/wallet/lib/proof.js
@@ -7,9 +7,9 @@ const { scanQR } = require('./util');
 const { initPackageManager } = require('./util');
 
 class ProofManager {
-  constructor(db) {
+  constructor(db, network) {
     this.db = db;
-    this.credmgr = new CredentialManager(db);
+    this.credmgr = new CredentialManager(db, network);
   }
 
   async init() {

--- a/v2/holder/wallet/lib/util.js
+++ b/v2/holder/wallet/lib/util.js
@@ -23,11 +23,10 @@ const jsQR = require('jsqr');
 const config = require('./config');
 const { CredentialsDataSource, IdentitiesDataSource, ProfilesDataSource } = require('./extensions/storage');
 
-async function initDataStorage(db, network = 'kaleido') {
-  let conf = Object.assign({}, defaultEthConnectionConfig);
-  Object.assign(conf, config[network]);
+async function initDataStorage(db, network) {
+  const conf = Object.assign({}, defaultEthConnectionConfig, config[network]);
 
-  var dataStorage = {
+  const dataStorage = {
     credential: new CredentialStorage(new CredentialsDataSource(db)),
     identity: new IdentityStorage(new IdentitiesDataSource(db), new ProfilesDataSource(db)),
     mt: new MerkleTreeLocalStorage(40),


### PR DESCRIPTION
This passes through the --network command line arg from "main" exec function to the `IdentityManager`, `CredentialManager` etc. Their constructors are changed to make the network a required arg, with the default, `kaleido`, determined in one spot.

Plus some minor cleanup if imports / requires etc.

FYI @jimthematrix 
